### PR TITLE
Constant penalty for proposer equivocations

### DIFF
--- a/specs/_features/maxeb_increase/capella.py
+++ b/specs/_features/maxeb_increase/capella.py
@@ -841,7 +841,7 @@ def is_eligible_for_activation(state: BeaconState, validator: Validator) -> bool
     )
 
 
-def is_slashable_validator(validator: Validator, epoch: Epoch) -> bool:
+def is_attester_slashable_validator(validator: Validator, epoch: Epoch) -> bool:
     """
     Check if ``validator`` is slashable.
     """
@@ -1816,7 +1816,7 @@ def process_attester_slashing(state: BeaconState, attester_slashing: AttesterSla
     slashed_any = False
     indices = set(attestation_1.attesting_indices).intersection(attestation_2.attesting_indices)
     for index in sorted(indices):
-        if is_slashable_validator(state.validators[index], get_current_epoch(state)):
+        if is_attester_slashable_validator(state.validators[index], get_current_epoch(state)):
             slash_validator(state, index)
             slashed_any = True
     assert slashed_any

--- a/specs/_features/maxeb_increase/capella.py
+++ b/specs/_features/maxeb_increase/capella.py
@@ -1699,7 +1699,7 @@ def process_block_header(state: BeaconState, block: BeaconBlock) -> None:
 
     # Verify proposer is not slashed
     proposer = state.validators[block.proposer_index]
-    assert not is_slashed_proposer(proposer)
+    assert not is_slashed_proposer(proposer) and not is_slashed_attester(proposer)
 
 
 def process_randao(state: BeaconState, body: BeaconBlockBody) -> None:


### PR DESCRIPTION
For MaxEB induced consolidation to be appealing and fair, the risk profile of slashing should not change. Since consolidated validators are more likely to be chosen block proposers, a proposer slashing penalty proportional to active balance breaks the desired symmetry.

Since proposing a block is a singular event, its equivocation penalty should be constant. Malicious attesting has weighted impacted, so it's slashing penalty must be weighted by effective balance.

To prevent replay of ProposerSlashing messages the validator is exited when processing the first equivocation for that index. Validators may attempt to escape penalties by exiting immediately after committing the offense, but the minimum 4 epoch exit epoch delay should be sufficient to allow the network to submit an equivocation proof