### PR TITLE
Validator consolidation via activation churn

### DIFF
--- a/specs/_features/maxeb_increase/capella.py
+++ b/specs/_features/maxeb_increase/capella.py
@@ -2015,8 +2015,8 @@ def process_consolidation(state: BeaconState, signed_consolidation: SignedConsol
     assert bls.FastAggregateVerify(pubkeys, signing_root, signed_consolidation.signature)
 
     # Exit source bypassing the exit churn
-    source.exit_epoch = compute_activation_exit_epoch(get_current_epoch(state))
-    source.withdrawable_epoch = Epoch(source.exit_epoch + config.MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
+    source_validator.exit_epoch = compute_activation_exit_epoch(get_current_epoch(state))
+    source_validator.withdrawable_epoch = Epoch(source_validator.exit_epoch + config.MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
 
     # Queue consolidation for further processing
     state.pending_consolidations.append(PendingConsolidation(source_index = consolidation.source_index,


### PR DESCRIPTION
A simplified version of https://github.com/michaelneuder/consensus-specs/pull/12 that does not require changes to the slashing logic.

On `process_consolidation` in a block:
* Make the source exit with the `exit_epoch = compute_activation_exit_epoch(get_current_epoch(state))` bypassing the exit churn
* Queue the consolidation with `consolidation_epoch = source.withdrawable_epoch`

On `epoch_processing`:
* If `current_epoch == pending_consolidation.epoch` and the source wasn’t slashed move the active balance
* The active balance is simply added to the activation churn as a top up of the target validator

Downsides:
* Waiting for `withdrawal_epoch` to finish consolidation
* Time needed to activate consolidated balance is unpredictable as the activation queue may get longer while keep waiting for the `withdrawal_epoch`