### PR TITLE
Make initial slashing penalty negligible

### DIFF
--- a/specs/_features/maxeb_increase/capella.py
+++ b/specs/_features/maxeb_increase/capella.py
@@ -233,6 +233,7 @@ PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX = uint64(3)
 MAX_BLS_TO_EXECUTION_CHANGES = 16
 MAX_WITHDRAWALS_PER_PAYLOAD = uint64(16)
 MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP = 16384
+MIN_SLASHING_PENALTY_QUOTIENT_MAXEB = uint64(65536)
 
 
 class Configuration(NamedTuple):
@@ -1206,7 +1207,7 @@ def slash_validator(state: BeaconState,
     validator.slashed = True
     validator.withdrawable_epoch = max(validator.withdrawable_epoch, Epoch(epoch + EPOCHS_PER_SLASHINGS_VECTOR))
     state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effective_balance
-    slashing_penalty = validator.effective_balance // MIN_SLASHING_PENALTY_QUOTIENT_BELLATRIX  # [Modified in Bellatrix]
+    slashing_penalty = validator.effective_balance // MIN_SLASHING_PENALTY_QUOTIENT_MAXEB  # [Modified in MAXEB]
     decrease_balance(state, slashed_index, slashing_penalty)
 
     # Apply proposer and whistleblower rewards


### PR DESCRIPTION
Sets initial slashing penalty quotient to a large number making the penalty negligibly low (around a few hours of rewards).

This change achieves an objective of removing the penalty in a less intrusive way simply by adjusting the existing constant instead of making more modifications to the code which makes it very easy in terms of implementation and testing.
