### PR TITLE
Allow to set custom EB ceiling

### DIFF
--- a/specs/_features/maxeb_increase/capella.py
+++ b/specs/_features/maxeb_increase/capella.py
@@ -2023,7 +2023,7 @@ def process_consolidation(state: BeaconState, signed_consolidation: SignedConsol
     assert source_validator.withdrawal_credentials[:1] in (ETH1_ADDRESS_WITHDRAWAL_PREFIX, COMPOUNDING_WITHDRAWAL_PREFIX)
     assert target_validator.withdrawal_credentials[:1] in (ETH1_ADDRESS_WITHDRAWAL_PREFIX, COMPOUNDING_WITHDRAWAL_PREFIX)
     # Verify the same withdrawal address
-    assert source_validator.withdrawal_credentials[1:] == target_validator.withdrawal_credentials[1:]
+    assert source_validator.withdrawal_credentials[12:] == target_validator.withdrawal_credentials[12:]
 
     # Verify consolidation is signed by the source and the target
     domain = compute_domain(DOMAIN_CONSOLIDATION, genesis_validators_root=state.genesis_validators_root)


### PR DESCRIPTION
A minimal change allowing to set custom ceiling for a validator:

* Interprets bytes [1, 3] of 0x02 withdrawal credentials as a custom ceiling parameter
* No way to directly update custom ceiling, consolidation to a validator with a higher ceiling can be used as a work around 